### PR TITLE
Add ConfigOptionsCommand to display available configuration options

### DIFF
--- a/src/Commands/ConfigOptionsCommand.php
+++ b/src/Commands/ConfigOptionsCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Orkestra\Commands;
+
+use Orkestra\Interfaces\ConfigurationInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConfigOptionsCommand extends Command
+{
+    protected static $defaultName = 'app:config:options';
+
+    public function __construct(
+        private ConfigurationInterface $config
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('List the available configuration options for the application.')
+            ->setHelp('This command lists the available configuration options for the application.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Available configuration options:');
+        $output->writeln('');
+
+        $definition = $this->config->get('definition');
+
+        $definition = array_map(function ($value, $key) {
+            return [$key, $value[0] ? 'Yes' : 'No', $value[1]];
+        }, $definition, array_keys($definition));
+        
+        // Create a table to display the configuration options, with key, required, and description columns
+        $table = new Table($output);
+        $table
+        ->setHeaders(['Key', 'Required', 'Description'])
+        ->setRows($definition);
+
+        $table->render();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Providers/CommandsProvider.php
+++ b/src/Providers/CommandsProvider.php
@@ -3,6 +3,7 @@
 namespace Orkestra\Providers;
 
 use Orkestra\App;
+use Orkestra\Commands\ConfigOptionsCommand;
 use Orkestra\Interfaces\ProviderInterface;
 use Orkestra\Commands\StartServerCommand;
 
@@ -16,6 +17,7 @@ class CommandsProvider implements ProviderInterface
 	 */
 	protected array $commands = [
 		StartServerCommand::class,
+		ConfigOptionsCommand::class,
 	];
 
 	/**
@@ -72,6 +74,10 @@ class CommandsProvider implements ProviderInterface
 				}
 				return true;
 			},
+		]);
+
+		$app->config()->set('definition', [
+			'commands'  => [false, 'The commands to register with the console application'],
 		]);
 	}
 

--- a/src/Providers/HooksProvider.php
+++ b/src/Providers/HooksProvider.php
@@ -29,6 +29,10 @@ class HooksProvider implements ProviderInterface
 			},
 		]);
 
+		$app->config()->set('definition', [
+			'listeners'  => [false, 'The hook listeners to register with the app'],
+		]);
+
 		$app->singleton(HooksInterface::class, Hooks::class);
 	}
 

--- a/src/Providers/HttpProvider.php
+++ b/src/Providers/HttpProvider.php
@@ -43,6 +43,11 @@ class HttpProvider implements ProviderInterface
 			},
 		]);
 
+		$app->config()->set('definition', [
+			'routes'  => [true, 'The routes directory to load'],
+			'middleware'  => [false, 'The middleware to load'],
+		]);
+
 		$app->singleton(Router::class, Router::class);
 		$app->singleton(Validator::class, Validator::class);
 		$app->singleton(RouterInterface::class, Router::class);

--- a/src/Traits/AppContainerTrait.php
+++ b/src/Traits/AppContainerTrait.php
@@ -133,13 +133,8 @@ trait AppContainerTrait
      *
      * @template T
      * @param class-string<T> $name   Entry name or a class name.
-     * @param mixed[]         $params Optional parameters to use to build the entry. Use this to force
-     *                                specific parameters to specific values. Parameters not defined in this
-     *                                array will be resolved using the container.
+     * @param mixed[]         $params Optional parameters to use to build the entry.
      * @return T
-     * @throws InvalidArgumentException The name parameter must be of type string.
-     * @throws DependencyException Error while resolving the entry.
-     * @throws NotFoundException No entry found for the given name.
      */
     public function get(string $name, array $params = []): mixed
     {


### PR DESCRIPTION
This pull request adds a new command called ConfigOptionsCommand to the application. This command allows users to list the available configuration options for the application. The command displays a table with the key, required flag, and description of each configuration option.