### PR TITLE
feat: add config default values

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -18,14 +18,38 @@ class App implements ContainerInterface, AppHooksInterface
     use AppHooksTrait;
 
     public function __construct(
-        ConfigurationInterface $config,
+        private ConfigurationInterface $config,
     ) {
-        // Define default container
+        $this->setDefaultConfig();
         $this->initContainer($config);
         $this->singleton(ConfigurationInterface::class, $config);
         $this->singleton(ContainerInterface::class, $this);
         $this->singleton(AppHooksInterface::class, $this);
         $this->singleton(self::class, $this);
+    }
+
+    private function setDefaultConfig(): void
+    {
+        $this->config->set('validation', [
+			'env'  => fn ($value) =>
+                !in_array($value, ['development', 'production', 'testing'], true)
+                    ? 'env must be either "development", "production" or "testing"'
+                    : true,
+			'root' => fn ($value) =>
+                !is_dir($value ?? '')
+                    ? "root \"$value\" is not a directory"
+                    : true,
+			'slug' => fn ($value) =>
+                !empty($value) && !preg_match('/^[a-z0-9-]+$/', $value)
+                    ? "slug \"$value\" is not valid"
+                    : true,
+		]);
+
+		$this->config->set('definition', [
+			'env'  => ['The environment the app is running in (development, production)', 'development'],
+			'root' => ['The root directory of the app', getcwd()],
+			'slug' => ['The app slug', 'app'],
+		]);
     }
 
     /**
@@ -48,7 +72,7 @@ class App implements ContainerInterface, AppHooksInterface
      */
     public function config(): ConfigurationInterface
     {
-        return $this->get(ConfigurationInterface::class);
+        return $this->config;
     }
 
     /**

--- a/src/Commands/ConfigOptionsCommand.php
+++ b/src/Commands/ConfigOptionsCommand.php
@@ -34,7 +34,7 @@ class ConfigOptionsCommand extends Command
         $definition = $this->config->get('definition');
 
         $definition = array_map(function ($value, $key) {
-            return [$key, $value[0] ? 'Yes' : 'No', $value[1]];
+            return [$key, isset($value[1]) ? 'Yes' : 'No', $value[0]];
         }, $definition, array_keys($definition));
         
         // Create a table to display the configuration options, with key, required, and description columns

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -112,6 +112,11 @@ class Configuration implements ConfigurationInterface
 
 	public function has(string $key): bool
 	{
-		return (bool) $this->get($key);
+		try {
+			$this->get($key);
+			return true;
+		} catch (InvalidArgumentException) {
+			return false;
+		}
 	}
 }

--- a/src/Interfaces/ConfigurationInterface.php
+++ b/src/Interfaces/ConfigurationInterface.php
@@ -15,11 +15,17 @@ interface ConfigurationInterface
 	public function validate(): bool;
 
 	/**
-	 * Set a configuration value
-	 * 
-	 * If the key is 'validation' then the value must be an array with keys as the config key and the value as a callable
-	 * and the callable must return true if the value is valid or a string with the error message if the value is invalid.
-	 * This array will be merged with the existing validation array.
+	 * Set a configuration value.
+	 *
+	 * Can be used to set the following keys:
+	 * - validation: array<string, fn ($value): bool|string>
+	 * - definition: array<string, [description, ?default]>
+	 * - any other key: the value to set
+	 *
+	 * - The validation should return true if the value is valid,
+	 * or a string with the error message.
+	 * - If the description does not have a default value, the
+	 * config turns into a required value.
 	 *
 	 * @param string $key
 	 * @param mixed $value
@@ -31,10 +37,9 @@ interface ConfigurationInterface
 	 * Get a configuration value
 	 *
 	 * @param string $key
-	 * @param mixed $default
 	 * @return mixed
 	 */
-	public function get(string $key, mixed $default = null): mixed;
+	public function get(string $key): mixed;
 
 	/**
 	 * Check if a configuration value exists

--- a/src/Providers/CommandsProvider.php
+++ b/src/Providers/CommandsProvider.php
@@ -33,7 +33,7 @@ class CommandsProvider implements ProviderInterface
 	{
 		$app->singleton(Application::class, function () use ($app) {
 			/** @var class-string[] */
-			$commands  = $app->config()->get('commands', []);
+			$commands  = $app->config()->get('commands');
 			$providers = $app->getProviders();
 			$console   = new Application($app->slug());
 
@@ -59,7 +59,6 @@ class CommandsProvider implements ProviderInterface
 			// 'app_name' => fn ($value) => is_string($value) ? true : 'App name must be a string',
 			'commands' => function ($value) {
 				$extendedClass = Command::class;
-				$value = $value ?? [];
 				if (!is_array($value)) {
 					return "Commands must be an array with command classes extending \"$extendedClass\"";
 				}
@@ -78,7 +77,7 @@ class CommandsProvider implements ProviderInterface
 		]);
 
 		$app->config()->set('definition', [
-			'commands'  => [false, 'The commands to register with the console application'],
+			'commands'  => ['Commands to register with the console application', []],
 		]);
 	}
 

--- a/src/Providers/HooksProvider.php
+++ b/src/Providers/HooksProvider.php
@@ -25,12 +25,12 @@ class HooksProvider implements ProviderInterface
 	{
 		$app->config()->set('validation', [
 			'listeners' => function ($value) {
-				return is_array($value ?? []) ? true : 'The listeners config must be an array';
+				return is_array($value) ? true : 'The listeners config must be an array';
 			},
 		]);
 
 		$app->config()->set('definition', [
-			'listeners'  => [false, 'The hook listeners to register with the app'],
+			'listeners'  => ['The hook listeners to register with the app', []],
 		]);
 
 		$app->singleton(HooksInterface::class, Hooks::class);
@@ -45,7 +45,7 @@ class HooksProvider implements ProviderInterface
 	public function boot(App $app): void
 	{
 		/** @var class-string[] */
-		$listeners = $app->config()->get('listeners', []);
+		$listeners = $app->config()->get('listeners');
 		$hooks     = $app->get(HooksInterface::class);
 
 		$this->registerListeners($app, $hooks, $listeners);

--- a/src/Providers/HttpProvider.php
+++ b/src/Providers/HttpProvider.php
@@ -36,16 +36,16 @@ class HttpProvider implements ProviderInterface
 		// Set the required config so we can validate it
 		$app->config()->set('validation', [
 			'routes' => function ($value) {
-				return is_string($value ?? '') ? true : 'The routes config must be a string path to a file';
+				return is_string($value) ? true : 'The routes config must be a string path to a file';
 			},
 			'middleware' => function ($value) {
-				return is_array($value ?? []) ? true : 'The middleware config must be an array';
+				return is_array($value) ? true : 'The middleware config must be an array';
 			},
 		]);
 
 		$app->config()->set('definition', [
-			'routes'  => [false, 'The routes directory to load'],
-			'middleware'  => [false, 'The middleware to load'],
+			'routes'  => ['The routes directory to load', ''],
+			'middleware'  => ['The middleware to load', []],
 		]);
 
 		$app->singleton(Router::class, Router::class);
@@ -87,7 +87,7 @@ class HttpProvider implements ProviderInterface
 	 */
 	public function boot(App $app): void
 	{
-		$middleware = $app->config()->get('middleware', []);
+		$middleware = $app->config()->get('middleware');
 
 		/** @var mixed[] */
 		$middleware = $app->hookQuery('http.middleware', $middleware);
@@ -104,7 +104,7 @@ class HttpProvider implements ProviderInterface
 		/** @var string */
 		$configFile = $app->config()->get('routes');
 
-		if (!$configFile) {
+		if (empty($configFile)) {
 			$app->hookCall('http.router.config', $router);
 			return;
 		}

--- a/src/Providers/ViewProvider.php
+++ b/src/Providers/ViewProvider.php
@@ -43,6 +43,30 @@ class ViewProvider implements ProviderInterface
 	 */
 	public function register(App $app): void
 	{
+		$url = function () use ($app): string {
+			$protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+			$host = $app->config()->get('host');
+			return "$protocol://$host";
+		};
+
+		$app->config()->set('validation', [
+			'host'    => fn ($value) => !is_string($value)
+				? 'host must be a string with the domain of the app'
+				: true,
+			'url'     => fn ($value) => !is_string($value)
+				? 'url must be a string with the URL of the app'
+				: true,
+			'assets'  => fn ($value) => !is_string($value)
+				? 'assets must be a string with the URL of the assets'
+				: true,
+		]);
+
+		$app->config()->set('definition', [
+			'host'   => ['The host domain of the app', fn() => $_SERVER['HTTP_HOST'] ?? 'localhost'],
+			'url'    => ['The URL of the app', $url],
+			'assets' => ['The URL of the assets', fn () => $app->config()->get('url') . '/assets'],
+		]);
+
 		/**
 		 * Register runtime interfaces
 		 */

--- a/src/Services/View/Twig/OrkestraExtension.php
+++ b/src/Services/View/Twig/OrkestraExtension.php
@@ -104,8 +104,8 @@ class OrkestraExtension extends AbstractExtension
 		}
 		// If is relative we should get our settings url
 		if (strpos($src, 'http') === false) {
-			$publicUrl = rtrim($this->config->get('public_url', ''), '/') . '/';
-			$src = $publicUrl . ltrim($src, '/');
+			$assetsUrl = rtrim($this->config->get('assets'), '/') . '/';
+			$src = $assetsUrl . ltrim($src, '/');
 		}
 
 		$tag = new HtmlTag('script', [
@@ -128,8 +128,8 @@ class OrkestraExtension extends AbstractExtension
 	{
 		// If is relative we should get our settings url
 		if (strpos($href, 'http') === false) {
-			$publicUrl = rtrim($this->config->get('public_url', ''), '/') . '/';
-			$href = $publicUrl . ltrim($href, '/');
+			$assetsUrl = rtrim($this->config->get('assets'), '/') . '/';
+			$href = $assetsUrl . ltrim($href, '/');
 		}
 
 		$this->headTags[] = new HtmlTag('link', [

--- a/src/Traits/AppContainerTrait.php
+++ b/src/Traits/AppContainerTrait.php
@@ -42,10 +42,6 @@ trait AppContainerTrait
         $isProduction = $config->get('env') === 'production';
         $cacheDir     = $config->get('root');
 
-        if ($isProduction && !is_string($cacheDir)) {
-            throw new InvalidArgumentException('The root directory must be a string');
-        }
-
         if ($isProduction) {
             /** @var string $cacheDir */
             $containerBuilder->enableCompilation($cacheDir);

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -132,16 +132,6 @@ test('can check if container has service', function () {
     expect($this->app->has('test'))->toBeTrue();
 });
 
-test('can throw exception when booting without env', function () {
-    $this->config->set('root', './');
-    $this->app->boot();
-})->throws(InvalidArgumentException::class);
-
-test('can throw exception when booting without root', function () {
-    $this->config->set('env', 'development');
-    $this->app->boot();
-})->throws(InvalidArgumentException::class);
-
 test('can throw exception when booting twice', function () {
     $this->config->set('env', 'development');
     $this->config->set('root', './');

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Orkestra\Configuration;
+
+test('can instantiate the Configuration class', function () {
+    $config = new Configuration([]);
+    expect($config)->toBeInstanceOf(Configuration::class);
+});
+
+test('can validate configuration', function () {
+    $config = new Configuration([
+        'definition' => [
+            'key1' => ['description1', 'default1'],
+            'key2' => ['description2', 'default2'],
+        ],
+        'validation' => [
+            'key1' => fn($value) => $value === 'default1',
+            'key2' => fn($value) => $value === 'default2',
+        ],
+    ]);
+
+    expect($config->validate())->toBeTrue();
+});
+
+test('can set and get configuration', function () {
+    $config = new Configuration([]);
+    $config->set('key', 'value');
+
+    expect($config->get('key'))->toBe('value');
+});
+
+test('can check if configuration exists', function () {
+    $config = new Configuration(['key' => 'value']);
+
+    expect($config->has('key'))->toBeTrue();
+    expect($config->has('nonexistent_key'))->toBeFalse();
+});
+
+
+test('can throw exception when validating undefined configuration key', function () {
+    $config = new Configuration([
+        'undefinedKey' => 'value',
+        'definition' => [],
+        'validation' => [],
+    ]);
+	$config->validate();
+})->throws(InvalidArgumentException::class);
+
+test('can throw exception when required configuration key is missing', function () {
+    $config = new Configuration([
+        'definition' => [
+            'requiredKey' => ['description', null],
+        ],
+        'validation' => [],
+    ]);
+	$config->validate();
+})->throws(InvalidArgumentException::class);
+
+test('can throw exception when configuration does not pass validation', function () {
+    $config = new Configuration([
+        'key' => 'invalidValue',
+        'definition' => [
+            'key' => ['description', 'validValue'],
+        ],
+        'validation' => [
+            'key' => fn($value) => $value === 'validValue',
+        ],
+    ]);
+	$config->validate();
+})->throws(InvalidArgumentException::class);
+
+test('can throw exception when setting invalid validation', function () {
+    $config = new Configuration([]);
+	$config->set('validation', 'invalidValue');
+})->throws(InvalidArgumentException::class);
+
+test('can throw exception when setting invalid definition', function () {
+    $config = new Configuration([]);
+	$config->set('definition', 'invalidValue');
+})->throws(InvalidArgumentException::class);
+
+test('can throw exception when getting undefined configuration key', function () {
+    $config = new Configuration([]);
+	$config->get('undefinedKey');
+})->throws(InvalidArgumentException::class);
+
+test('can throw exception when getting required configuration key that is not set', function () {
+    $config = new Configuration([
+        'definition' => [
+            'requiredKey' => ['description', null],
+        ],
+    ]);
+	$config->get('requiredKey');
+})->throws(InvalidArgumentException::class);

--- a/tests/Unit/Services/View/ViewTest.php
+++ b/tests/Unit/Services/View/ViewTest.php
@@ -41,12 +41,12 @@ test('can render a html view with head tags', function () {
 test('can render script tags', function () {
 	/** @var ViewInterface */
 	$view = app()->get(ViewInterface::class);
-	app()->config()->set('public_url', 'http://localhost');
+	app()->config()->set('assets', 'http://localhost/assets');
 	$rendered = $view->render('script');
 
 	// Remove line breaks added in template
 	$rendered = preg_replace('/\s+/', ' ', $rendered);
-	expect($rendered)->toBe('<!DOCTYPE html><html lang="en"><head><script src="http://localhost/head1.js" type=""></script><script src="http://localhost/head2.js" type=""></script><script src="http://localhost/defered.js" defer type=""></script><script src="http://localhost/async.js" async type=""></script><script src="http://localhost/module.js" type="module"></script></head><body> <script src="http://localhost/footer.js" type=""></script></body></html>');
+	expect($rendered)->toBe('<!DOCTYPE html><html lang="en"><head><script src="http://localhost/assets/head1.js" type=""></script><script src="http://localhost/assets/head2.js" type=""></script><script src="http://localhost/assets/defered.js" defer type=""></script><script src="http://localhost/assets/async.js" async type=""></script><script src="http://localhost/assets/module.js" type="module"></script></head><body> <script src="http://localhost/assets/footer.js" type=""></script></body></html>');
 });
 
 test('can render js constants', function () {
@@ -63,22 +63,23 @@ test('can render js constants', function () {
 test('can respect script and const order', function () {
 	/** @var ViewInterface */
 	$view = app()->get(ViewInterface::class);
+	app()->config()->set('host', 'localhost');
 	$rendered = $view->render('script-const-order');
 
 	// Remove line breaks added in template
 	$rendered = preg_replace('/\s+/', ' ', $rendered);
-	expect($rendered)->toBe('<!DOCTYPE html><html lang="en"><head><script src="/head1.js" type=""></script><script>const const1 = {"test":"test1"};</script><script src="/head2.js" type=""></script><script>const const2 = {"test":"test2"};</script></head><body> <script>const constFooter1 = {"test":"test1"};</script><script src="/footer.js" type=""></script><script>const constFooter2 = {"test":"test2"};</script></body></html>');
+	expect($rendered)->toBe('<!DOCTYPE html><html lang="en"><head><script src="http://localhost/assets/head1.js" type=""></script><script>const const1 = {"test":"test1"};</script><script src="http://localhost/assets/head2.js" type=""></script><script>const const2 = {"test":"test2"};</script></head><body> <script>const constFooter1 = {"test":"test1"};</script><script src="http://localhost/assets/footer.js" type=""></script><script>const constFooter2 = {"test":"test2"};</script></body></html>');
 });
 
 test('can render with css links', function () {
 	/** @var ViewInterface */
 	$view = app()->get(ViewInterface::class);
-	app()->config()->set('public_url', 'http://localhost');
+	app()->config()->set('assets', 'http://localhost/assets');
 	$rendered = $view->render('css');
 
 	// Remove line breaks added in template
 	$rendered = preg_replace('/\s+/', ' ', $rendered);
-	expect($rendered)->toBe('<!DOCTYPE html><html lang="en"><head><link rel="stylesheet" href="http://localhost/style1.css" /><link rel="stylesheet" href="http://localhost/style2.css" /></head><body> </body></html>');
+	expect($rendered)->toBe('<!DOCTYPE html><html lang="en"><head><link rel="stylesheet" href="http://localhost/assets/style1.css" /><link rel="stylesheet" href="http://localhost/assets/style2.css" /></head><body> </body></html>');
 });
 
 test('can autoload twig runtime extensions with app container', function () {


### PR DESCRIPTION
Changes the config defnition to includes a optional default value.

If the default value exists the config turns into optonal.

```php
$app->config()->set('definition', [
    'my_config'  => ['My config description', 'default value'],
]);

```

Also, the update ensures that all used configurations are defined, throwing errors when undefined config is added or requestetd.

```php
foreach ($this->config as $key => $value) {
	if ($key === 'validation' || $key === 'definition') {
		continue;
	}
	if (!isset($definitions[$key])) {
		throw new InvalidArgumentException("Configuration key \"$key\" does not have a definition");
	}
	unset($definitions[$key]);
}

foreach ($definitions as $key => $definition) {
	if (!isset($definition[1]) && !isset($this->config[$key])) {
		throw new InvalidArgumentException("Configuration key \"$key\" is required");
	}
}
```