### PR TITLE
feat: get middleware from providers

### DIFF
--- a/src/Commands/ConfigOptionsCommand.php
+++ b/src/Commands/ConfigOptionsCommand.php
@@ -3,15 +3,15 @@
 namespace Orkestra\Commands;
 
 use Orkestra\Interfaces\ConfigurationInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'app:config:list')]
 class ConfigOptionsCommand extends Command
 {
-    protected static $defaultName = 'app:config:options';
-
     public function __construct(
         private ConfigurationInterface $config
     ) {

--- a/src/Commands/StartServerCommand.php
+++ b/src/Commands/StartServerCommand.php
@@ -2,16 +2,16 @@
 
 namespace Orkestra\Commands;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(name: 'app:serve')]
 class StartServerCommand extends Command
 {
-    protected static $defaultName = 'app:serve';
-
     protected function configure()
     {
         $this

--- a/src/Providers/HttpProvider.php
+++ b/src/Providers/HttpProvider.php
@@ -2,6 +2,7 @@
 
 namespace Orkestra\Providers;
 
+use InvalidArgumentException;
 use Orkestra\App;
 use Orkestra\Interfaces\ProviderInterface;
 
@@ -18,10 +19,18 @@ use Laminas\Diactoros\ResponseFactory;
 use Psr\Http\Message\ResponseInterface;
 
 use League\Route\Strategy\JsonStrategy;
+use Orkestra\Services\Http\Commands\MiddlewareListCommand;
 use Rakit\Validation\Validator;
 
 class HttpProvider implements ProviderInterface
 {
+	/**
+	 * @var array<class-string<Command>>
+	 */
+	public array $commands = [
+		MiddlewareListCommand::class,
+	];
+
 	/**
 	 * Register services with the container.
 	 * We can use the container to bind services to the app.
@@ -87,6 +96,39 @@ class HttpProvider implements ProviderInterface
 	 */
 	public function boot(App $app): void
 	{
+		$middlewareStack = $app->config()->get('middleware');
+		$middlewareSources = array_map(fn () => 'configuration', $middlewareStack);
+		foreach ($app->getProviders() as $provider) {
+			$provider = $app->get($provider);
+			if (!property_exists($provider, 'middleware')) {
+				continue;
+			}
+			if (!is_array($provider->middleware)) {
+				throw new InvalidArgumentException(sprintf('Middleware must be an array in %s', $provider::class));
+			}
+			foreach ($provider->middleware as $alias => $middleware) {
+				if (!is_string($alias)) {
+					throw new InvalidArgumentException(sprintf('Middleware alias must be a string in %s', $provider::class));
+				}
+				if (!is_string($middleware)) {
+					throw new InvalidArgumentException(sprintf('Middleware must be a class string in %s', $provider::class));
+				}
+				if (!isset($middlewareStack[$alias])) {
+					$middlewareStack[$alias] = $middleware;
+					$middlewareSources[$alias] = $provider::class;
+				}
+			}
+		}
+
+		$app->config()->set('definition', [
+			'middleware_sources' => [
+				'Middleware stack sources',
+				$middlewareSources,
+			],
+		]);
+
+		$app->config()->set('middleware', $middlewareStack);
+
 		$router = $app->get(RouterInterface::class);
 		$router->setStrategy($app->get(ApplicationStrategy::class));
 
@@ -100,5 +142,28 @@ class HttpProvider implements ProviderInterface
 
 		(require $configFile)($router);
 		$app->hookCall('http.router.config', $router);
+	}
+
+	/**
+	 * @param class-string[] $listeners
+	 */
+	protected function registerListeners(App $app, HooksInterface $hooks, array $listeners): void
+	{
+		foreach ($listeners as $listener) {
+			// Set listeners as singletons
+			$app->singleton($listener, $listener);
+			/** @var ListenerInterface */
+			$listener = $app->get($listener);
+			$listenerHooks = $listener->hook();
+			$listenerHooks = is_array($listenerHooks) ? $listenerHooks : [$listenerHooks];
+			foreach ($listenerHooks as $listenerHook) {
+				if (!method_exists($listener, 'handle')) {
+					throw new Exception(sprintf('Listener %s must implement handle method', $listener::class));
+				}
+				$listenerHook = str_replace('{app}', $app->slug(), $listenerHook);
+				// @phpstan-ignore-next-line
+				$hooks->register($listenerHook, $listener->handle(...));
+			}
+		}
 	}
 }

--- a/src/Services/Http/Commands/MiddlewareListCommand.php
+++ b/src/Services/Http/Commands/MiddlewareListCommand.php
@@ -33,7 +33,7 @@ class MiddlewareListCommand extends Command
         /** @var array<string, string> */
         $middlewareStack = $this->config->get('middleware');
         /** @var array<string, string> */
-		$middlewareSources = $this->config->get('middleware_sources');
+        $middlewareSources = $this->config->get('middleware_sources');
 
         $definition = array_map(function ($middleware, $alias) use ($middlewareSources) {
             return [$alias, $middleware, $middlewareSources[$alias] ?? ''];
@@ -41,8 +41,8 @@ class MiddlewareListCommand extends Command
 
         $table = new Table($output);
         $table
-        ->setHeaders(['Alias', 'Middleware', 'Placed By'])
-        ->setRows($definition);
+            ->setHeaders(['Alias', 'Middleware', 'Placed By'])
+            ->setRows($definition);
 
         $table->render();
 

--- a/src/Services/Http/Commands/MiddlewareListCommand.php
+++ b/src/Services/Http/Commands/MiddlewareListCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Orkestra\Services\Http\Commands;
+
+use Orkestra\Interfaces\ConfigurationInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'middleware:list')]
+class MiddlewareListCommand extends Command
+{
+    public function __construct(
+        private ConfigurationInterface $config
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('List the available middleware for the application.')
+            ->setHelp('This command lists the available middleware stack for the application.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Available middleware options:');
+        $output->writeln('');
+
+        /** @var array<string, string> */
+        $middlewareStack = $this->config->get('middleware');
+        /** @var array<string, string> */
+		$middlewareSources = $this->config->get('middleware_sources');
+
+        $definition = array_map(function ($middleware, $alias) use ($middlewareSources) {
+            return [$alias, $middleware, $middlewareSources[$alias] ?? ''];
+        }, $middlewareStack, array_keys($middlewareStack));
+
+        $table = new Table($output);
+        $table
+        ->setHeaders(['Alias', 'Middleware', 'Placed By'])
+        ->setRows($definition);
+
+        $table->render();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Unit/Services/Http/CommandsTest.php
+++ b/tests/Unit/Services/Http/CommandsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Orkestra\App;
+use Orkestra\Interfaces\ProviderInterface;
+use Orkestra\Providers\CommandsProvider;
+use Orkestra\Providers\HttpProvider;
+use Orkestra\Services\Http\Commands\MiddlewareListCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class TestProvider1 implements ProviderInterface
+{
+	public array $middleware = [
+		'middleware1' => 'Middleware1',
+		'middleware3' => 'Middleware3',
+		'middleware4' => 'Middleware4',
+	];
+	public function register(App $app): void {}
+	public function boot(App $app): void {}
+}
+
+class TestProvider2 implements ProviderInterface
+{
+	public array $middleware = [
+		'middleware4' => 'Middleware4',
+		'middleware5' => 'Middleware5',
+	];
+	public function register(App $app): void {}
+	public function boot(App $app): void {}
+}
+
+beforeEach(function () {
+	app()->provider(TestProvider1::class);
+	app()->provider(TestProvider2::class);
+	app()->provider(CommandsProvider::class);
+	app()->provider(HttpProvider::class);
+	app()->config()->set('middleware', [
+		'middleware1' => 'Middleware1',
+		'middleware2' => 'Middleware2',
+	]);
+});
+
+test('can list the available middleware', function () {
+	$tester = new CommandTester(app()->get(MiddlewareListCommand::class));
+	$tester->execute([], ['interactive' => false]);
+
+	$outputLines = explode(PHP_EOL, $tester->getDisplay());
+
+    // Check the number of lines in the output
+	expect(count($outputLines))->toBe(12);
+
+    // Check the content of each line
+	expect($outputLines[0]) ->toBe('Available middleware options:');
+	expect($outputLines[1]) ->toBe('');
+	expect($outputLines[2]) ->toBe('+-------------+-------------+---------------+');
+	expect($outputLines[3]) ->toBe('| Alias       | Middleware  | Placed By     |');
+	expect($outputLines[4]) ->toBe('+-------------+-------------+---------------+');
+	expect($outputLines[5]) ->toBe('| middleware1 | Middleware1 | configuration |');
+	expect($outputLines[6]) ->toBe('| middleware2 | Middleware2 | configuration |');
+	expect($outputLines[7]) ->toBe('| middleware3 | Middleware3 | TestProvider1 |');
+	expect($outputLines[8]) ->toBe('| middleware4 | Middleware4 | TestProvider1 |');
+	expect($outputLines[9]) ->toBe('| middleware5 | Middleware5 | TestProvider2 |');
+	expect($outputLines[10])->toBe('+-------------+-------------+---------------+');
+	expect($outputLines[11])->toBe('');
+});

--- a/tests/Unit/Services/Http/CommandsTest.php
+++ b/tests/Unit/Services/Http/CommandsTest.php
@@ -45,10 +45,10 @@ test('can list the available middleware', function () {
 
 	$outputLines = explode(PHP_EOL, $tester->getDisplay());
 
-    // Check the number of lines in the output
+	// Check the number of lines in the output
 	expect(count($outputLines))->toBe(12);
 
-    // Check the content of each line
+	// Check the content of each line
 	expect($outputLines[0]) ->toBe('Available middleware options:');
 	expect($outputLines[1]) ->toBe('');
 	expect($outputLines[2]) ->toBe('+-------------+-------------+---------------+');


### PR DESCRIPTION
This PR adds a command to list the active middleware stack aliases and allow the registration of aliases through 
a provider parameter.

The middleware stack priorises the midleware that is firstly added, alowing the user to easily override a middleware from a provider using the configuration stack as we can see from the command test.


```bash
+-------------+-------------+---------------+
| Alias       | Middleware  | Placed By     |
+-------------+-------------+---------------+
| middleware1 | Middleware1 | configuration |
| middleware2 | Middleware2 | configuration |
| middleware3 | Middleware3 | TestProvider1 |
| middleware4 | Middleware4 | TestProvider1 |
| middleware5 | Middleware5 | TestProvider2 |
+-------------+-------------+---------------+
```

```php
class TestProvider1 implements ProviderInterface
{
	public array $middleware = [
		'middleware1' => 'Middleware1',
		'middleware3' => 'Middleware3',
		'middleware4' => 'Middleware4',
	];
	public function register(App $app): void {}
	public function boot(App $app): void {}
}
```