### PR TITLE
feat: uses php-di default singleton

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,11 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduced the `Orkestra\App::decorate()` method, enabling service decoration during container resolution.
-- Enhanced container operations `call`, `get`, `has` and `decorate` to verify application boot state.
+- Introduced the `Orkestra\App::make()` method for resolving new instances from the container.
 
 ### Changed
 
 - Modified `Orkestra\AppContainerTrait` to built the container during the application boot process.
+- Modified `Orkestra\App::get()` according psr-11 signature to only accept one argument.
+- Enhanced container operations `call`, `get`, `has` and `decorate` to verify application boot state.
+
+### Deprecated
+
+- Deprecated the `Orkestra\App::singleton()` method in favor of `Orkestra\App::bind()` only.
 
 ## [1.0.1] - 2024-05-11
 

--- a/src/App.php
+++ b/src/App.php
@@ -23,11 +23,11 @@ class App implements AppHooksInterface, AppContainerInterface
     ) {
         $this->setDefaultConfig();
         $this->initContainer();
-        $this->singleton(ConfigurationInterface::class, $config);
-        $this->singleton(ContainerInterface::class, $this);
-        $this->singleton(AppContainerInterface::class, $this);
-        $this->singleton(AppHooksInterface::class, $this);
-        $this->singleton(self::class, $this);
+        $this->bind(ConfigurationInterface::class, $config);
+        $this->bind(ContainerInterface::class, $this);
+        $this->bind(AppContainerInterface::class, $this);
+        $this->bind(AppHooksInterface::class, $this);
+        $this->bind(self::class, $this);
     }
 
     private function setDefaultConfig(): void

--- a/src/Entities/EntityFactory.php
+++ b/src/Entities/EntityFactory.php
@@ -40,7 +40,7 @@ class EntityFactory
             $properties  = array_merge($fakerArgs['properties'], $properties);
         }
 
-        $entity = $this->app->get($class, $constructor);
+        $entity = $this->app->make($class, $constructor);
 
         foreach ($properties as $key => $value) {
             if (method_exists($entity, $method = 'set' . ucfirst($key))) {

--- a/src/Interfaces/AppContainerInterface.php
+++ b/src/Interfaces/AppContainerInterface.php
@@ -39,27 +39,23 @@ interface AppContainerInterface extends ContainerInterface
     public function bind(string $name, mixed $service, bool $useAutowire = true): AppBind;
 
     /**
-     * Add a service to the container as a singleton
+     * Returns an entry of the container by its name.
      *
-     * @param string $name
-     * @param mixed  $service
-     * @param bool   $useAutowire
-     * @return AppBind A bind instance that allows manage the service constructor and properties
-     * @throws InvalidArgumentException If the class specified in $service does not exist
+     * @template T of object
+     * @param class-string<T> $name   Entry name or a class name.
+     * @return T
      */
-    public function singleton(string $name, mixed $service, bool $useAutowire = true): ?AppBind;
+    public function get(string $name): mixed;
 
     /**
-     * Returns an entry of the container by its name.
-     * If the entry is a singleton, it will return the same instance,
-     * otherwise, it will create a new instance.
+     * Resolves the given entry from the container.
      *
      * @template T of object
      * @param class-string<T> $name   Entry name or a class name.
      * @param mixed[]         $params Optional parameters to use to build the entry.
      * @return T
      */
-    public function get(string $name, array $params = []): mixed;
+    public function make(string $name, array $params = []): mixed;
 
     /**
      * Call the given function using the given parameters.

--- a/src/Providers/CommandsProvider.php
+++ b/src/Providers/CommandsProvider.php
@@ -31,7 +31,7 @@ class CommandsProvider implements ProviderInterface
      */
     public function register(App $app): void
     {
-        $app->singleton(Application::class, function () use ($app) {
+        $app->bind(Application::class, function () use ($app) {
             /** @var class-string[] */
             $commands  = $app->config()->get('commands');
             $providers = $app->getProviders();

--- a/src/Providers/HooksProvider.php
+++ b/src/Providers/HooksProvider.php
@@ -33,7 +33,7 @@ class HooksProvider implements ProviderInterface
             'listeners'  => ['The hook listeners to register with the app', []],
         ]);
 
-        $app->singleton(HooksInterface::class, Hooks::class);
+        $app->bind(HooksInterface::class, Hooks::class);
     }
 
     /**
@@ -65,8 +65,7 @@ class HooksProvider implements ProviderInterface
     protected function registerListeners(App $app, HooksInterface $hooks, array $listeners): void
     {
         foreach ($listeners as $listener) {
-            // Set listeners as singletons
-            $app->singleton($listener, $listener);
+            $app->bind($listener, $listener);
             /** @var ListenerInterface */
             $listener = $app->get($listener);
             $listenerHooks = $listener->hook();

--- a/src/Providers/HttpProvider.php
+++ b/src/Providers/HttpProvider.php
@@ -57,9 +57,9 @@ class HttpProvider implements ProviderInterface
             'middleware'  => ['The middleware to load', []],
         ]);
 
-        $app->singleton(Router::class, Router::class);
-        $app->singleton(Validator::class, Validator::class);
-        $app->singleton(RouterInterface::class, Router::class);
+        $app->bind(Router::class, Router::class);
+        $app->bind(Validator::class, Validator::class);
+        $app->bind(RouterInterface::class, Router::class);
 
         $app->bind(ServerRequestInterface::class, function () {
             return ServerRequestFactory::fromGlobals(

--- a/src/Providers/ViewProvider.php
+++ b/src/Providers/ViewProvider.php
@@ -81,7 +81,7 @@ class ViewProvider implements ProviderInterface
             $app->config()->get('root') . '/views',
         );
 
-        $app->singleton(Environment::class, function (
+        $app->bind(Environment::class, function (
             RuntimeLoaderInterface $runtimeLoader,
             LoaderInterface        $loader,
         ) use ($app) {

--- a/src/Services/Http/Router.php
+++ b/src/Services/Http/Router.php
@@ -50,7 +50,7 @@ class Router extends LeagueRouter implements RouterInterface
     public function map(string $method, string $path, $handler): Route
     {
         $path  = sprintf('/%s', ltrim($path, '/'));
-        $route = $this->app->get(Route::class, [
+        $route = $this->app->make(Route::class, [
             'method'  => $method,
             'path'    => $path,
             'handler' => $handler
@@ -63,7 +63,7 @@ class Router extends LeagueRouter implements RouterInterface
 
     public function group(string $prefix, callable $group): RouteGroup
     {
-        $group = $this->app->get(RouteGroup::class, [
+        $group = $this->app->make(RouteGroup::class, [
             'prefix'     => $prefix,
             'callback'   => $group,
             'collection' => $this

--- a/src/Services/Http/Strategy/ApplicationStrategy.php
+++ b/src/Services/Http/Strategy/ApplicationStrategy.php
@@ -59,7 +59,7 @@ class ApplicationStrategy extends AbstractStrategy implements ContainerAwareInte
             }
             /** @var string */
             $str = is_string($response) ? $response : json_encode($response);
-            $response = $this->app->get(ResponseInterface::class);
+            $response = $this->app->make(ResponseInterface::class);
             $response->getBody()->write($str);
         }
 

--- a/src/Services/Http/Traits/ErrorResponseTrait.php
+++ b/src/Services/Http/Traits/ErrorResponseTrait.php
@@ -49,7 +49,7 @@ trait ErrorResponseTrait
         $contentType = $request->getHeaderLine('Content-Type');
 
         if (strpos($contentType, 'application/json') === 0) {
-            $response = $this->app->get(JsonResponse::class, [
+            $response = $this->app->make(JsonResponse::class, [
                 'data' => [
                     'status'      => 'error',
                     'code'        => $code,

--- a/src/Services/Http/Traits/MiddlewareAwareTrait.php
+++ b/src/Services/Http/Traits/MiddlewareAwareTrait.php
@@ -90,7 +90,7 @@ trait MiddlewareAwareTrait
         // If the middleware is an array we should resolve from App instance
         if (is_array($middleware) && $this->app->has($middleware[0])) {
             // @phpstan-ignore-next-line
-            $middleware = $this->app->get(...$middleware);
+            $middleware = $this->app->make(...$middleware);
         }
 
         if ($middleware instanceof MiddlewareInterface) {

--- a/src/Services/Http/Traits/RouteDefinitionTrait.php
+++ b/src/Services/Http/Traits/RouteDefinitionTrait.php
@@ -74,8 +74,8 @@ trait RouteDefinitionTrait
     public function getDefinition(): RouteDefinitionFacade
     {
         if (is_string($this->definition)) {
-            $this->definition = $this->app->get(RouteDefinitionFacade::class, [
-                'definition' => $this->app->get($this->definition, $this->definitionParams)
+            $this->definition = $this->app->make(RouteDefinitionFacade::class, [
+                'definition' => $this->app->make($this->definition, $this->definitionParams)
             ]);
         }
 
@@ -83,8 +83,8 @@ trait RouteDefinitionTrait
             $group = method_exists($this, 'getParentGroup') ? $this->getParentGroup() : null;
             $parentDefinition = $group ? $group->getDefinition() : null;
             $definition = array_merge($this->definition, ['parentDefinition' => $parentDefinition]);
-            $this->definition = $this->app->get(RouteDefinitionFacade::class, [
-                'definition' => $this->app->get(RouteDefinition::class, $definition)
+            $this->definition = $this->app->make(RouteDefinitionFacade::class, [
+                'definition' => $this->app->make(RouteDefinition::class, $definition)
             ]);
         }
 

--- a/src/Testing/AbstractTestCase.php
+++ b/src/Testing/AbstractTestCase.php
@@ -38,7 +38,7 @@ abstract class AbstractTestCase extends BaseTestCase
 
         // Register a new application in each test
         $container->add(App::class, $app);
-        $container->add(EntityFactory::class, $app->get(EntityFactory::class, ['useFaker' => true]));
+        $container->add(EntityFactory::class, $app->make(EntityFactory::class, ['useFaker' => true]));
     }
 
     /**

--- a/src/Traits/AppContainerTrait.php
+++ b/src/Traits/AppContainerTrait.php
@@ -18,11 +18,6 @@ trait AppContainerTrait
     private Container $container;
 
     /**
-     * @var array<string, bool>
-     */
-    private array $singletons = [];
-
-    /**
      * @var class-string[]
      */
     private array $providers = [];
@@ -45,7 +40,7 @@ trait AppContainerTrait
             throw new InvalidArgumentException("Provider \"$class\" must implement \"$interface\"");
         }
         $this->providers[] = $class;
-        $this->singleton($class, $class, false);
+        $this->bind($class, $class, false);
 
         /** @var ProviderInterface $instance */
         $instance = $this->get($class);
@@ -63,23 +58,22 @@ trait AppContainerTrait
         return new AppBind($this->container, $name, $service, $useAutowire);
     }
 
-    public function singleton(string $name, mixed $service, bool $useAutowire = true): ?AppBind
+    /**
+     * @template T of object
+     * @return T
+     */
+    public function get(string $name): mixed
     {
-        $bind = $this->bind($name, $service, $useAutowire);
-        $this->singletons[$name] = true;
-        return $bind;
+        /** @var T */
+        return $this->container->get($name);
     }
 
     /**
      * @template T of object
      * @return T
      */
-    public function get(string $name, array $params = []): mixed
+    public function make(string $name, array $params = []): mixed
     {
-        if (isset($this->singletons[$name])) {
-            /** @var T */
-            return $this->container->get($name);
-        }
         /** @var T */
         return $this->container->make($name, $params);
     }

--- a/src/Traits/AppContainerTrait.php
+++ b/src/Traits/AppContainerTrait.php
@@ -59,6 +59,15 @@ trait AppContainerTrait
     }
 
     /**
+     * @deprecated 1.1.0 Use bind instead
+     */
+    public function singleton(string $name, mixed $service, bool $useAutowire = true): ?AppBind
+    {
+        trigger_error('Method ' . __METHOD__ . ' is deprecated', E_USER_DEPRECATED);
+        return $this->bind($name, $service, $useAutowire);
+    }
+
+    /**
      * @template T of object
      * @return T
      */

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -35,9 +35,9 @@ test('can not get from container with non existent key', function () {
     $this->app->get('nonExistentKey');
 });
 
-test('can get from container with constructor parameters', function () {
+test('can make from container with constructor parameters', function () {
     $this->app->bind('test', fn ($param) => $param);
-    expect($this->app->get('test', ['param' => 'testValue']))->toEqual('testValue');
+    expect($this->app->make('test', ['param' => 'testValue']))->toEqual('testValue');
 });
 
 test('can register a provider', function () {
@@ -86,7 +86,8 @@ test('can bind a class in container by name', function () {
     expect($this->app->get('testClassString'))->toBeInstanceOf(get_class($class));
     $instance = $this->app->get('testClassString');
     $instance->value = 'testValue2';
-    $this->assertNotEquals($instance, $this->app->get('testClassString'));
+    $this->assertEquals($instance, $this->app->get('testClassString'));
+    $this->assertNotEquals($instance, $this->app->make('testClassString'));
 });
 
 test('can bind a class instance in container', function () {
@@ -96,18 +97,6 @@ test('can bind a class instance in container', function () {
     $this->app->bind('testClass', $class);
     expect($this->app->get('testClass'))->toBeInstanceOf(get_class($class));
     expect($this->app->get('testClass'))->toEqual($class);
-});
-
-test('can instantiate a singleton in the container', function () {
-    $class = new class () {
-        public string $value;
-    };
-
-    $this->app->singleton('testClassString', $class::class);
-    expect($this->app->get('testClassString'))->toBeInstanceOf(get_class($class));
-    $instance = $this->app->get('testClassString');
-    $instance->value = 'testValue2';
-    expect($this->app->get('testClassString'))->toEqual($instance);
 });
 
 test('can run if available with existing class', function () {

--- a/tests/Unit/Entities/EntitiesTest.php
+++ b/tests/Unit/Entities/EntitiesTest.php
@@ -47,7 +47,7 @@ test('can make a new entity', function () {
 
 test('can make a new entity with faker', function () {
     $app = app();
-    $factory = $app->get(EntityFactory::class, ['useFaker' => true]);
+    $factory = $app->make(EntityFactory::class, ['useFaker' => true]);
     $entity = $factory->make(EntityTest::class);
     expect($entity)->toBeInstanceOf(EntityTest::class);
     expect($entity->name)->toBeString();

--- a/tests/Unit/Services/Http/ValidationTest.php
+++ b/tests/Unit/Services/Http/ValidationTest.php
@@ -27,7 +27,7 @@ test('can add a route definition with validation and default value', function ()
 
 test('can add a route definition class with validation', function () {
     $definition = Mockery::mock(DefinitionInterface::class);
-    app()->singleton($definition::class, function () use ($definition) {
+    app()->bind($definition::class, function () use ($definition) {
         $factory = app()->get(ParamDefinitionFactory::class);
         $definition->shouldReceive('params')->andReturn([
             $factory->String(
@@ -46,7 +46,7 @@ test('can add a route definition class with validation', function () {
 
 test('can add inner parameters as array', function () {
     $definition = Mockery::mock(DefinitionInterface::class);
-    app()->singleton($definition::class, function () use ($definition) {
+    app()->bind($definition::class, function () use ($definition) {
         $factory = app()->get(ParamDefinitionFactory::class);
         $definition->shouldReceive('params')->andReturn([
             $factory->Array(
@@ -76,7 +76,7 @@ test('can add inner parameters as array', function () {
 
 test('can validate a request with a route definition', function () {
     $definition = Mockery::mock(DefinitionInterface::class);
-    app()->singleton($definition::class, function () use ($definition) {
+    app()->bind($definition::class, function () use ($definition) {
         $factory = app()->get(ParamDefinitionFactory::class);
         $definition->shouldReceive('params')->andReturn([
             $factory->String(
@@ -102,7 +102,7 @@ test('can validate a request with a route definition', function () {
 
 test('can validate a request with inner parameters', function () {
     $definition = Mockery::mock(DefinitionInterface::class);
-    app()->singleton($definition::class, function () use ($definition) {
+    app()->bind($definition::class, function () use ($definition) {
         $factory = app()->get(ParamDefinitionFactory::class);
         $definition->shouldReceive('params')->andReturn([
             $factory->Array(


### PR DESCRIPTION
This PR proposes key modifications to improve the consistency and standardization of container resolution methods in the Orkestra\App class. Here are the changes outlined:

**Removal of Orkestra\App::singleton():** This method currently acts merely as a wrapper for Orkestra\App::get(), fetching an existing instance from the container or creating a new one. This process ignores the container's native singleton handling during class resolution.
**Enhancement of Orkestra\App::get():** We are simplifying this method by removing its wrapping functionality, which currently involves unnecessary complexity in instance retrieval.
**Introduction of Orkestra\App::make():** This new method will be added to facilitate the creation of new instances directly from the container. This aligns with the conventional practices of dependency injection and instance management.

These changes are intended to align Orkestra\App with standard container resolution practices, enhancing maintainability and clarity.

**Important Note:** This update introduces breaking changes and should be incorporated into a new minor release. This precaution is advisable as the package currently has a limited user base, and a minor release will provide adequate notice to developers about the changes.