### PR TITLE
fix: configuration list required values

### DIFF
--- a/.github/workflows/allow-target.yml
+++ b/.github/workflows/allow-target.yml
@@ -6,6 +6,7 @@ on:
     types:
       - synchronize
       - opened
+      - edited
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Binds the `middleware.sources` in container instead of add a new configuration definition.
+- Updates `env` configuration definition to specify `testing` as a valid value.
+
+### Fixed
+
+- Makes the `app:config:list` command to show the correct required values.

--- a/src/App.php
+++ b/src/App.php
@@ -48,7 +48,7 @@ class App implements AppHooksInterface, AppContainerInterface
         ]);
 
         $this->config->set('definition', [
-            'env'  => ['The environment the app is running in (development, production)', 'development'],
+            'env'  => ['The environment the app is running in (development, production or testing)', 'development'],
             'root' => ['The root directory of the app', getcwd()],
             'slug' => ['The app slug', 'app'],
         ]);

--- a/src/Commands/ConfigOptionsCommand.php
+++ b/src/Commands/ConfigOptionsCommand.php
@@ -34,7 +34,7 @@ class ConfigOptionsCommand extends Command
         $definition = $this->config->get('definition');
 
         $definition = array_map(function ($value, $key) {
-            return [$key, isset($value[1]) ? 'Yes' : 'No', $value[0]];
+            return [$key, isset($value[1]) ? 'No' : 'Yes', $value[0]];
         }, $definition, array_keys($definition));
 
         // Create a table to display the configuration options, with key, required, and description columns

--- a/src/Providers/HttpProvider.php
+++ b/src/Providers/HttpProvider.php
@@ -122,12 +122,7 @@ class HttpProvider implements ProviderInterface
             }
         }
 
-        $app->config()->set('definition', [
-            'middleware_sources' => [
-                'Middleware stack sources',
-                $middlewareSources,
-            ],
-        ]);
+        $app->bind('middleware.sources', fn () => $middlewareSources);
 
         $app->config()->set('middleware', $middlewareStack);
 

--- a/src/Services/Http/Commands/MiddlewareListCommand.php
+++ b/src/Services/Http/Commands/MiddlewareListCommand.php
@@ -2,8 +2,8 @@
 
 namespace Orkestra\Services\Http\Commands;
 
-use Orkestra\Interfaces\AppContainerInterface;
 use Orkestra\Interfaces\ConfigurationInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -15,7 +15,7 @@ class MiddlewareListCommand extends Command
 {
     public function __construct(
         private ConfigurationInterface $config,
-        private AppContainerInterface $container,
+        private ContainerInterface $container,
     ) {
         parent::__construct();
     }

--- a/src/Services/Http/Commands/MiddlewareListCommand.php
+++ b/src/Services/Http/Commands/MiddlewareListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Orkestra\Services\Http\Commands;
 
+use Orkestra\Interfaces\AppContainerInterface;
 use Orkestra\Interfaces\ConfigurationInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -13,7 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class MiddlewareListCommand extends Command
 {
     public function __construct(
-        private ConfigurationInterface $config
+        private ConfigurationInterface $config,
+        private AppContainerInterface $container,
     ) {
         parent::__construct();
     }
@@ -33,7 +35,7 @@ class MiddlewareListCommand extends Command
         /** @var array<string, string> */
         $middlewareStack = $this->config->get('middleware');
         /** @var array<string, string> */
-        $middlewareSources = $this->config->get('middleware_sources');
+        $middlewareSources = $this->container->get('middleware.sources');
 
         $definition = array_map(function ($middleware, $alias) use ($middlewareSources) {
             return [$alias, $middleware, $middlewareSources[$alias] ?? ''];


### PR DESCRIPTION
This pull request fixes the required values in the configuration list command `app:config:list`.

It updates the `env` key to include the option of "testing" as a valid environment. It also updates the `execute` method to correctly display the required values in the configuration table.

Additionally, it binds the `middleware.sources` in container instead of add a new configuration key.