### PR TITLE
feat: add App:decorator

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2024-05-11
+## [Unreleased]
 
 ### Added
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Introduced the `Orkestra\App::decorate()` method, enabling service decoration during container resolution.
+- Enhanced container operations `call`, `get`, `has` and `decorate` to verify application boot state.
+
+### Changed
+
+- Modified `Orkestra\AppContainerTrait` to built the container during the application boot process.

--- a/src/App.php
+++ b/src/App.php
@@ -11,8 +11,6 @@ use Orkestra\Traits\AppHooksTrait;
 
 use Psr\Container\ContainerInterface;
 
-use Exception;
-
 class App implements AppHooksInterface, AppContainerInterface
 {
     use AppContainerTrait;
@@ -85,10 +83,9 @@ class App implements AppHooksInterface, AppContainerInterface
      */
     public function boot(): void
     {
-        // Ensure we only run once
-        if ($this->has('booted')) {
-            throw new Exception('App already booted');
-        }
+        $this->bootGate();
+
+        $this->bootContainer();
 
         $this->hookCall('config.validate.before', $this);
 

--- a/src/AppBind.php
+++ b/src/AppBind.php
@@ -10,9 +10,9 @@ use DI;
 use InvalidArgumentException;
 
 /**
- * @param readonly string $name
- * @param readonly mixed $service
- * @param readonly bool $autowire
+ * @property-read string $name
+ * @property-read mixed $service
+ * @property-read bool $autowire
  */
 class AppBind extends AbstractEntity
 {

--- a/src/AppBind.php
+++ b/src/AppBind.php
@@ -2,19 +2,25 @@
 
 namespace Orkestra;
 
-use DI\Container;
+use Orkestra\Entities\AbstractEntity;
 use DI\Definition\Helper\CreateDefinitionHelper;
+use DI\Container;
 use DI;
 
 use InvalidArgumentException;
 
-class AppBind
+/**
+ * @param readonly string $name
+ * @param readonly mixed $service
+ * @param readonly bool $autowire
+ */
+class AppBind extends AbstractEntity
 {
     public function __construct(
-        protected Container $container,
-        protected string    $name,
-        protected mixed     $service,
-        protected bool      $autowire = true
+        protected string     $name,
+        protected mixed      $service,
+        protected bool       $autowire = true,
+        private   ?Container $container = null,
     ) {
         $isClassString = is_string($service);
 
@@ -26,7 +32,7 @@ class AppBind
             ? ($autowire ? DI\autowire($service) : DI\create($service))
             : $service;
 
-        $this->set();
+        $this->update();
     }
 
     /**
@@ -45,7 +51,7 @@ class AppBind
             throw new InvalidArgumentException('Cannot define constructor parameters for a non-class services');
         }
         $this->service->constructor(...$parameters);
-        return $this->set();
+        return $this->update();
     }
 
     /**
@@ -62,7 +68,7 @@ class AppBind
             throw new InvalidArgumentException('Cannot define property injection for a non-class services');
         }
         $this->service->property($property, $value);
-        return $this->set();
+        return $this->update();
     }
 
     /**
@@ -85,12 +91,14 @@ class AppBind
             throw new InvalidArgumentException('Cannot define method calls for a non-class services');
         }
         $this->service->method($method, ...$parameters);
-        return $this->set();
+        return $this->update();
     }
 
-    protected function set(): self
+    protected function update(): self
     {
-        $this->container->set($this->name, $this->service);
+        if ($this->container) {
+            $this->container->set($this->name, $this->service);
+        }
         return $this;
     }
 }

--- a/src/Interfaces/AppContainerInterface.php
+++ b/src/Interfaces/AppContainerInterface.php
@@ -6,6 +6,7 @@ use Psr\Container\ContainerInterface;
 
 use Orkestra\AppBind;
 use InvalidArgumentException;
+use BadMethodCallException;
 
 interface AppContainerInterface extends ContainerInterface
 {
@@ -48,6 +49,25 @@ interface AppContainerInterface extends ContainerInterface
      * @throws InvalidArgumentException If the class specified in $service does not exist
      */
     public function singleton(string $name, mixed $service, bool $useAutowire = true): ?AppBind;
+
+    /**
+     * Decorate a service in the container
+     *
+     * The $decorator function should receive the original service as the
+     * first argument and return the new service.
+     * You can resolve other services in the container using other arguments.
+     * 
+     * Example:
+     * $container->decorate(Service::class, function (Service $service, OtherService $otherService) {
+     *    return new ServiceDecorator($service, $otherService);
+     * });
+     *
+     * @param class-string $name      Name of the service
+     * @param callable     $decorator Decorator function
+     * @throws BadMethodCallException   If the application is already booted this modification should not be allowed
+     * @throws InvalidArgumentException If the class does not exist
+     */
+    public function decorate(string $name, callable $decorator): void;
 
     /**
      * Returns an entry of the container by its name.

--- a/src/Interfaces/AppContainerInterface.php
+++ b/src/Interfaces/AppContainerInterface.php
@@ -56,7 +56,7 @@ interface AppContainerInterface extends ContainerInterface
      * The $decorator function should receive the original service as the
      * first argument and return the new service.
      * You can resolve other services in the container using other arguments.
-     * 
+     *
      * Example:
      * $container->decorate(Service::class, function (Service $service, OtherService $otherService) {
      *    return new ServiceDecorator($service, $otherService);

--- a/src/Testing/AbstractTestCase.php
+++ b/src/Testing/AbstractTestCase.php
@@ -38,7 +38,6 @@ abstract class AbstractTestCase extends BaseTestCase
 
         // Register a new application in each test
         $container->add(App::class, $app);
-        $container->add(EntityFactory::class, $app->get(EntityFactory::class, ['useFaker' => true]));
     }
 
     /**
@@ -66,6 +65,7 @@ abstract class AbstractTestCase extends BaseTestCase
         $app = $container->get(App::class);
         $app->boot();
 
+        $container->add(EntityFactory::class, $app->get(EntityFactory::class, ['useFaker' => true]));
         parent::assertPreConditions();
     }
 }

--- a/src/Traits/AppContainerTrait.php
+++ b/src/Traits/AppContainerTrait.php
@@ -23,8 +23,8 @@ trait AppContainerTrait
 
     private Container $container;
 
-    /** 
-     * @var ContainerBuilder<Container> 
+    /**
+     * @var ContainerBuilder<Container>
      */
     private ContainerBuilder $builder;
 

--- a/src/Traits/AppContainerTrait.php
+++ b/src/Traits/AppContainerTrait.php
@@ -19,11 +19,14 @@ use function DI\decorate;
  */
 trait AppContainerTrait
 {
+    private bool $booted = false;
+
     private Container $container;
 
+    /** 
+     * @var ContainerBuilder<Container> 
+     */
     private ContainerBuilder $builder;
-
-    private bool $booted = false;
 
     /**
      * @var array<string, bool>
@@ -41,7 +44,7 @@ trait AppContainerTrait
     private array $decorators = [];
 
     /**
-     * @var array<string, callable[]>
+     * @var array<string, DefinitionHelper>
      */
     private array $rootDecorators = [];
 

--- a/tests/Unit/AppBindTest.php
+++ b/tests/Unit/AppBindTest.php
@@ -4,43 +4,40 @@ use Orkestra\AppBind;
 use DI\Container;
 use DI\Definition\Helper\CreateDefinitionHelper;
 
-beforeEach(function () {
-    $this->container = $this->createMock(Container::class);
-});
-
 test('can create a bind with class name', function () {
-    $this->container->expects($this->once())->method('set')->with(
+    $container = $this->createMock(Container::class);
+    $container->expects($this->once())->method('set')->with(
         $this->equalTo('test'),
         $this->equalTo(DI\autowire(self::class)),
     );
 
-    expect(new AppBind($this->container, 'test', self::class))->toBeInstanceOf(AppBind::class);
+    expect(new AppBind('test', self::class, container: $container))->toBeInstanceOf(AppBind::class);
 });
 
 test('can create a bind with class name and no autowire', function () {
-    // Check if the container set method was called with the correct arguments
-    $this->container->expects($this->once())->method('set')->with(
+    $container = $this->createMock(Container::class);
+    $container->expects($this->once())->method('set')->with(
         $this->equalTo('test'),
         $this->equalTo(DI\create(self::class)),
     );
 
-    expect(new AppBind($this->container, 'test', self::class, false))->toBeInstanceOf(AppBind::class);
+    expect(new AppBind('test', self::class, false, $container))->toBeInstanceOf(AppBind::class);
 });
 
 test('can create a bind with closure', function () {
-    $this->container->expects($this->once())->method('set')->with(
+    $container = $this->createMock(Container::class);
+    $container->expects($this->once())->method('set')->with(
         $this->equalTo('test'),
         $this->equalTo(fn () => true),
     );
-    expect(new AppBind($this->container, 'test', fn () => true))->toBeInstanceOf(AppBind::class);
+    expect(new AppBind('test', fn () => true, container: $container))->toBeInstanceOf(AppBind::class);
 });
 
 test('can not create a bind with non existent class', function () {
-    new AppBind($this->container, 'test', 'nonExistentClass');
+    new AppBind('test', 'nonExistentClass');
 })->throws(Exception::class);
 
 test('can set constructor params', function () {
-    // Mock the existing service so we can test the constructor method
     $mockedService = $this->createMock(CreateDefinitionHelper::class);
     $mockedService->expects($this->once())
         ->method('constructor')
@@ -49,17 +46,16 @@ test('can set constructor params', function () {
             $this->equalTo('testValue2')
         );
 
-    $bind = new AppBind($this->container, 'test', $mockedService);
+    $bind = new AppBind('test', $mockedService);
     $bind->constructor('testValue1', 'testValue2');
 });
 
 test('can not set constructor params with non class service', function () {
-    $bind = new AppBind($this->container, 'test', fn () => true);
+    $bind = new AppBind('test', fn () => true);
     $bind->constructor('testValue1');
 })->throws(Exception::class);
 
 test('can set service property', function () {
-    // Mock the existing service so we can test the property method
     $mockedService = $this->createMock(CreateDefinitionHelper::class);
     $mockedService->expects($this->once())
         ->method('property')
@@ -68,17 +64,16 @@ test('can set service property', function () {
             $this->equalTo('testValue')
         );
 
-    $bind = new AppBind($this->container, 'test', $mockedService);
+    $bind = new AppBind('test', $mockedService);
     $bind->property('testProperty', 'testValue');
 });
 
 test('can not set service property with non class service', function () {
-    $bind = new AppBind($this->container, 'test', fn () => true);
+    $bind = new AppBind('test', fn () => true);
     $bind->property('testProperty', 'testValue');
 })->throws(Exception::class);
 
 test('can inject method parameters into service', function () {
-    // Mock the existing service so we can test the method method
     $mockedService = $this->createMock(CreateDefinitionHelper::class);
     $mockedService->expects($this->once())
         ->method('method')
@@ -88,13 +83,13 @@ test('can inject method parameters into service', function () {
             $this->equalTo('testValue2')
         );
 
-    $bind = new AppBind($this->container, 'test', $mockedService);
+    $bind = new AppBind('test', $mockedService);
 
     $bind->method('testMethod', 'testValue1', 'testValue2');
 });
 
 test('can not inject method parameters into non class service', function () {
     $this->expectException(Exception::class);
-    $bind = new AppBind($this->container, 'test', fn () => true);
+    $bind = new AppBind('test', fn () => true);
     $bind->method('testMethod', 'testValue1', 'testValue2');
 });

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -176,7 +176,7 @@ test('can boot all existing providers', function () {
 test('can decorate a service', function () {
     $mock = Mockery::mock();
     $mock->shouldReceive('test')->andReturn('testValue');
-    
+
     $mock2 = Mockery::mock();
     $mock2->shouldReceive('test')->andReturn('testValueDecorated');
 
@@ -199,7 +199,7 @@ test('can decorate a service before add to container', function () {
             return 'testValue';
         }
     };
-    
+
     $mock2 = Mockery::mock();
     $mock2->shouldReceive('test')->andReturn('testValueDecorated');
 

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -212,7 +212,8 @@ test('can decorate a service before add to container', function () {
 });
 
 test('can decorate a bind interface', function () {
-    interface TestInterface {
+    interface TestInterface
+    {
         public function test();
     }
 


### PR DESCRIPTION
This pull request introduces a valuable enhancement to the `AppContainerInterface` with the addition of the decorate method. This method allow incorporate multiple decorators for a service class.

## Key Features:

* Decorator Flexibility: The decorate method enables the attachment of multiple decorators to a specific service class, offering flexibility in enhancing its behavior.
* Simplified Usage: With this method, users can effortlessly append multiple layers of functionality to a service class, enhancing its capabilities without modifying its core implementation.

## Example usage

```php
// Registering multiple decorators for the Service class
$container->decorate(Service::class, function (Service $service) {
    // First decorator logic
    return $service;
});

$container->decorate(Service::class, function (Service $service) {
    // Second decorator logic
    return $service;
});
```

## Benefits:

* Enhanced Modularity: Developers can now compose complex behaviors by combining multiple decorators, promoting modularity and maintainability in the codebase.
* Improved Extensibility: The ability to attach multiple decorators facilitates the seamless extension of services, accommodating evolving requirements with minimal overhead.

## Impact:

* Minimal Disruption: The addition of the decorate method introduces minimal disruption as it will keep all current funtionality while providing significant benefits in terms of extensibility and maintainability.
