### PR TITLE
feat: middleware testing

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced the `Orkestra\App::make()` method for resolving new instances from the container.
 - Allow the use of `Faker` attribute in class properties to generate fake data.
 - Automatically boot the application during test execution instead of throw an exception.
+- Introduce the `middleware` testing function and `Orkestra\Testing\Middleware` class to ease middleware testing.
 
 ### Changed
 

--- a/src/Testing/Middleware.php
+++ b/src/Testing/Middleware.php
@@ -10,6 +10,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Laminas\Diactoros\ResponseFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @property-read class-string           $name
+ * @property-read array<string, mixed>   $params
+ * @property-read string                 $method
+ * @property-read mixed[]                $data
+ * @property-read array<string, string>  $headers
+ * @property-read ServerRequestInterface $request
+ */
 class Middleware extends AbstractEntity
 {
     protected ?ServerRequestInterface $request = null;
@@ -45,7 +53,6 @@ class Middleware extends AbstractEntity
 
         /** @var TestCase */
         $test = test();
-
         $mockHandler = $test->getMockBuilder(RequestHandlerInterface::class)->getMock();
         $mockHandler->method('handle')->willReturnCallback($this->runController(...));
 

--- a/src/Testing/Middleware.php
+++ b/src/Testing/Middleware.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Orkestra\Testing;
+
+use Orkestra\Entities\AbstractEntity;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Laminas\Diactoros\ResponseFactory;
+
+class Middleware extends AbstractEntity
+{
+    protected ?ServerRequestInterface $request = null;
+
+    public function __construct(
+        protected string $name,
+        protected array $params = [],
+        protected string $method = 'GET',
+        protected array $data = [],
+        protected array $headers = []
+    ) {
+        //
+    }
+
+    private function runController(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->request = $request;
+        return (new ResponseFactory())->createResponse();
+    }
+
+    public function process(): ResponseInterface
+    {
+        $request = generateRequest($this->method, '/', $this->data, $this->headers);
+
+        /** @var MiddlewareInterface */
+        $middleware  = app()->make($this->name, $this->params);
+
+        $mockHandler = test()->createMock(RequestHandlerInterface::class);
+        $mockHandler->method('handle')->willReturnCallback($this->runController(...));
+
+        return $middleware->process($request, $mockHandler);
+    }
+}

--- a/src/Testing/Middleware.php
+++ b/src/Testing/Middleware.php
@@ -8,11 +8,18 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Laminas\Diactoros\ResponseFactory;
+use PHPUnit\Framework\TestCase;
 
 class Middleware extends AbstractEntity
 {
     protected ?ServerRequestInterface $request = null;
 
+    /**
+     * @param class-string          $name    Middleware class name
+     * @param array<string, mixed>  $params  Constructor parameters
+     * @param mixed[]               $data    Request data
+     * @param array<string, string> $headers Request headers
+     */
     public function __construct(
         protected string $name,
         protected array $params = [],
@@ -36,9 +43,13 @@ class Middleware extends AbstractEntity
         /** @var MiddlewareInterface */
         $middleware  = app()->make($this->name, $this->params);
 
-        $mockHandler = test()->createMock(RequestHandlerInterface::class);
+        /** @var TestCase */
+        $test = test();
+
+        $mockHandler = $test->getMockBuilder(RequestHandlerInterface::class)->getMock();
         $mockHandler->method('handle')->willReturnCallback($this->runController(...));
 
+        /** @var RequestHandlerInterface $mockHandler */
         return $middleware->process($request, $mockHandler);
     }
 }


### PR DESCRIPTION
This pull request introduces the middleware testing function and the Orkestra\Testing\Middleware class to ease middleware testing.

This simplifies the middleware test process by creating a custom request and mocking a Psr\Http\Server\RequestHandlerInterface, allowing us to properly analyze the middleware process call.

Below is an example from Sonata:

```php
it('should allow the access for a logged in user', function () {
	$user = Doctrine::factory(DoctrineUser::class)[0];
	Auth::actingAs($user);

	$middleware = middleware(AuthorizationMiddleware::class);
	$response = $middleware->process();
	expect($response->getStatusCode())->toBe(200);
});

it('should throw an exception for a guest user', function () {
	$middleware = middleware(AuthorizationMiddleware::class);
	$middleware->process();
})->expectException(UnauthorizedException::class);
```

Also, we can get the resulted request from `process` execution:

```php
$middleware = middleware(AuthorizationMiddleware::class);
$middleware->process();
$middleware->request;
```